### PR TITLE
 remove default row actions like edit,quickedit, delete on snitch entrys

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8CH5FPR88QYML
 * Tags:              sniffer, snitch, network, monitoring, firewall
 * Requires at least: 3.8
-* Tested up to:      4.7
+* Tested up to:      4.7.2
 * Stable tag:        trunk
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
@@ -57,6 +57,12 @@ Network monitor for WordPress with connection overview for controlling and regul
 * WordPress 3.8 or greater
 
 ## Changelog ##
+### 1.1.7 ###
+* updated README
+* testet up to WordPress 4.7.2
+* added GitHub Updater Metadata
+* remove default row actions like edit,quickedit, delete on snitch entrys
+
 ### 1.1.6 ###
 * updated README
 * updated [plugin authors](https://gist.github.com/glueckpress/f058c0ab973d45a72720)

--- a/inc/snitch_cpt.class.php
+++ b/inc/snitch_cpt.class.php
@@ -200,6 +200,17 @@ class Snitch_CPT
 			10,
 			1
 		);
+
+		/*  row actions */
+		add_filter(
+			'post_row_actions',
+			array(
+				__CLASS__,
+				'row_actions'
+			),
+			10,
+			2
+		);
 	}
 
 
@@ -1085,5 +1096,21 @@ class Snitch_CPT
 		$screen = get_current_screen();
 
 		return ( is_object($screen) && $screen->id === $id );
+	}
+
+	/**
+	 * Default row actions unterdrücken
+	 *
+	 * @since   1.1.7
+	 * @param   array   $actions  Array mit den default Aktionen auf ein Post (Edit, Quickedit, löschen)
+	 * @param   objekt  $post
+	 * @return  array   $actions
+	 */
+	public static function row_actions( $actions, $post )
+	{
+		if ($post->post_type=='snitch') {
+			return;
+		}
+		return $actions;
 	}
 }

--- a/snitch.php
+++ b/snitch.php
@@ -7,13 +7,16 @@ Author URI:  http://pluginkollektiv.org
 Plugin URI:  https://wordpress.org/plugins/snitch/
 License:     GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Version:     1.1.6
+Version:     1.1.7
 Text Domain: snitch
 Domain Path: /lang
+GitHub Plugin URI: https://github.com/pluginkollektiv/snitch
+GitHub Branch: master
 */
 
 /*
 Copyright (C)  2013-2015 Sergej Müller
+Copyright (C)  2015-2017 Pluginkollektiv
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
* updated README
* testet up to WordPress 4.7.2
* added GitHub Updater Metadata
* remove default row actions like edit,quickedit, delete on snitch entrys  fixes: #12 
