### PR TITLE
update WPCS to v3 and apply minor code style tweaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "matthiasmullie/minify": "^1.3",
     "squizlabs/php_codesniffer": "^3.7",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "wp-coding-standards/wpcs": "^2.3"
+    "wp-coding-standards/wpcs": "^3.2"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60f11ad50916a1a60f6dda352f981e09",
+    "content-hash": "debec365b24561b416bb4920b4f4f716",
     "packages": [],
     "packages-dev": [
         {
@@ -436,6 +436,181 @@
             "time": "2025-05-12T16:38:37+00:00"
         },
         {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "882b8c947ada27eb002870fe77fee9ce0a454cdb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/882b8c947ada27eb002870fe77fee9ce0a454cdb",
+                "reference": "882b8c947ada27eb002870fe77fee9ce0a454cdb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.1.2",
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-05T06:54:52+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "b22b59e3d9ec8fe4953e42c7d59117c6eae70eae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/b22b59e3d9ec8fe4953e42c7d59117c6eae70eae",
+                "reference": "b22b59e3d9ec8fe4953e42c7d59117c6eae70eae",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.3 || ^4.0"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-05T00:00:03+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.13.4",
             "source": {
@@ -521,30 +696,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -561,6 +744,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -568,7 +752,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-07-24T20:08:31+00:00"
         }
     ],
     "aliases": [],

--- a/inc/class-snitch-blocklist.php
+++ b/inc/class-snitch-blocklist.php
@@ -24,7 +24,7 @@ class Snitch_Blocklist {
 	 * @param   string $type  Typ des Eintrags (hosts|files).
 	 */
 	public static function block( $items, $type ) {
-		 /* Type check */
+		/* Type check */
 		if ( ! in_array( $type, array( 'hosts', 'files' ) ) ) {
 			return;
 		}

--- a/inc/class-snitch-cpt.php
+++ b/inc/class-snitch-cpt.php
@@ -252,7 +252,7 @@ class Snitch_CPT {
 		$filter = ( ! isset( $_GET['snitch_state_filter'] ) ? '' : (int) $_GET['snitch_state_filter'] );
 
 		/* Filter dropdown */
-		echo sprintf(
+		printf(
 			'<select name="snitch_state_filter">%s%s%s</select>',
 			'<option value="">' . esc_html__( 'All states', 'snitch' ) . '</option>',
 			'<option value="' . esc_attr( SNITCH_AUTHORIZED ) . '" ' . selected( $filter, SNITCH_AUTHORIZED, false ) . '>' . esc_html__( 'Authorized', 'snitch' ) . '</option>',
@@ -484,7 +484,7 @@ class Snitch_CPT {
 		$blacklisted = in_array( $host, self::$options['hosts'] );
 
 		/* Print output */
-		echo sprintf(
+		printf(
 			'<div><p class="label blacklisted-%d"></p>%s<div class="row-actions">%s</div></div>',
 			esc_attr( $blacklisted ),
 			wp_kses(
@@ -541,7 +541,7 @@ class Snitch_CPT {
 		$blacklisted = in_array( $file, self::$options['files'] );
 
 		/* Print output */
-		echo sprintf(
+		printf(
 			'<div><p class="label blacklisted-%d"></p>%s: %s<br /><code>/%s:%d</code><div class="row-actions">%s</div></div>',
 			esc_attr( $blacklisted ),
 			esc_html( $meta['type'] ),
@@ -583,7 +583,7 @@ class Snitch_CPT {
 		);
 
 		/* Print the state */
-		echo sprintf(
+		printf(
 			'<span class="%s">%s</span>',
 			esc_attr( strtolower( $states[ $state ] ) ),
 			esc_html( $states[ $state ] )
@@ -591,7 +591,7 @@ class Snitch_CPT {
 
 		/* Colorize blocked item */
 		if ( SNITCH_BLOCKED === $state ) {
-			echo sprintf(
+			printf(
 				'<style>#post-%1$d {background:rgba(248, 234, 232, 0.8)}#post-%1$d.alternate {background:#f8eae8}</style>',
 				esc_attr( $post_id )
 			);
@@ -664,7 +664,7 @@ class Snitch_CPT {
 	 * @param   integer $post_id  Post-ID.
 	 */
 	private static function _html_created( $post_id ) {
-		echo sprintf(
+		printf(
 			/* translators: duration (e. g. "15 mins") since the post was created */
 			esc_html__( '%s ago', 'snitch' ),
 			esc_html( human_time_diff( get_post_time( 'G', true, $post_id ) ) )
@@ -699,7 +699,7 @@ class Snitch_CPT {
 		}
 
 		/* Thickbox content start */
-		echo sprintf(
+		printf(
 			'<div id="snitch-thickbox-%d" class="snitch-hidden"><pre>',
 			esc_attr( $post_id )
 		);
@@ -929,7 +929,7 @@ class Snitch_CPT {
 		$update_message = $_GET['updated'] > 0
 			? __( 'New rule added to the Snitch filter. Matches are labeled in red.', 'snitch' )
 			: __( 'An existing rule removed from the Snitch filter.', 'snitch' );
-		echo sprintf(
+		printf(
 			'<div class="updated"><p>%s</p></div>',
 			esc_html( $update_message )
 		);

--- a/inc/class-snitch-cpt.php
+++ b/inc/class-snitch-cpt.php
@@ -30,7 +30,7 @@ class Snitch_CPT {
 	 * @change  0.0.1
 	 */
 	public static function instance() {
-		 new self();
+		new self();
 	}
 
 	/**
@@ -40,30 +40,30 @@ class Snitch_CPT {
 	 * @change  1.1.3
 	 */
 	public function __construct() {
-		 /* Set plugin options */
+		/* Set plugin options */
 		self::$options = Snitch::get_options();
 
 		/* Post Type */
 		register_post_type(
 			'snitch',
 			array(
-				'label' => 'Snitch',
-				'labels' => array(
-					'not_found' => esc_html__( 'No items found. Future connections will be shown at this place.', 'snitch' ),
+				'label'               => 'Snitch',
+				'labels'              => array(
+					'not_found'          => esc_html__( 'No items found. Future connections will be shown at this place.', 'snitch' ),
 					'not_found_in_trash' => esc_html__( 'No items found in trash.', 'snitch' ),
-					'search_items' => esc_html__( 'Search in destination', 'snitch' ),
+					'search_items'       => esc_html__( 'Search in destination', 'snitch' ),
 				),
-				'public' => false,
-				'show_ui' => true,
-				'query_var' => true,
-				'hierarchical' => false,
-				'capabilities' => array(
+				'public'              => false,
+				'show_ui'             => true,
+				'query_var'           => true,
+				'hierarchical'        => false,
+				'capabilities'        => array(
 					'create_posts' => false,
 					'delete_posts' => false,
 				),
-				'menu_position' => 50,
-				'capability_type' => 'snitch',
-				'publicly_queryable' => false,
+				'menu_position'       => 50,
+				'capability_type'     => 'snitch',
+				'publicly_queryable'  => false,
 				'exclude_from_search' => true,
 			)
 		);
@@ -280,7 +280,7 @@ class Snitch_CPT {
 	 */
 	public static function expand_query_vars( $query ) {
 		if ( ! empty( $_GET['snitch_state_filter'] ) ) {
-			$query->query_vars['meta_key'] = '_snitch_state';
+			$query->query_vars['meta_key']   = '_snitch_state';
 			$query->query_vars['meta_value'] = (int) $_GET['snitch_state_filter'];
 		}
 	}
@@ -437,7 +437,7 @@ class Snitch_CPT {
 	 * @param   integer $post_id  Post-ID.
 	 */
 	public static function custom_column( $column, $post_id ) {
-		 /* Column types */
+		/* Column types */
 		$types = (array) apply_filters(
 			'snitch_custom_column',
 			array(
@@ -476,8 +476,8 @@ class Snitch_CPT {
 	 * @param   integer $post_id  Post-ID.
 	 */
 	private static function _html_url( $post_id ) {
-		 /* Init data */
-		$url = self::_get_meta( $post_id, 'url' );
+		/* Init data */
+		$url  = self::_get_meta( $post_id, 'url' );
 		$host = self::_get_meta( $post_id, 'host' );
 
 		/* Already blacklisted? */
@@ -504,7 +504,7 @@ class Snitch_CPT {
 				array(
 					'a' => array(
 						'class' => array(),
-						'href' => array(),
+						'href'  => array(),
 					),
 				)
 			)
@@ -557,7 +557,7 @@ class Snitch_CPT {
 				array(
 					'a' => array(
 						'class' => array(),
-						'href' => array(),
+						'href'  => array(),
 					),
 				)
 			)
@@ -607,7 +607,7 @@ class Snitch_CPT {
 	 */
 	private static function _html_https( $post_id ) {
 		/* Item state */
-		$url = self::_get_meta( $post_id, 'url' );
+		$url        = self::_get_meta( $post_id, 'url' );
 		$parsed_url = wp_parse_url( $url );
 
 		/* Print the state */
@@ -720,7 +720,7 @@ class Snitch_CPT {
 			array(
 				'a' => array(
 					'class' => array(),
-					'href' => array(),
+					'href'  => array(),
 				),
 			)
 		);
@@ -740,12 +740,12 @@ class Snitch_CPT {
 	private static function _action_link( $post_id, $type, $blacklisted = false ) {
 		if ( $blacklisted ) {
 			$action = 'unblock';
-			$text = 'host' === $type
+			$text   = 'host' === $type
 				? __( 'Unblock this host', 'snitch' )
 				: __( 'Unblock this file', 'snitch' );
 		} else {
 			$action = 'block';
-			$text = 'host' === $type
+			$text   = 'host' === $type
 				? __( 'Block this host', 'snitch' )
 				: __( 'Block this file', 'snitch' );
 		}
@@ -855,7 +855,7 @@ class Snitch_CPT {
 
 		/* Set vars */
 		$action = sanitize_text_field( wp_unslash( $_GET['action'] ) );
-		$type = sanitize_text_field( wp_unslash( $_GET['type'] ) );
+		$type   = sanitize_text_field( wp_unslash( $_GET['type'] ) );
 
 		/* Validate action and type */
 		if ( ! in_array( $action, array( 'block', 'unblock' ) ) || ! in_array( $type, array( 'host', 'file' ) ) ) {
@@ -977,8 +977,8 @@ class Snitch_CPT {
 	 */
 	public static function views_edit( $views ) {
 		$links = array(
-			'paypal' => '<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Donate', 'snitch' ) . '</a>',
-			'wiki' => '<a href="https://github.com/pluginkollektiv/snitch/wiki" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Manual', 'snitch' ) . '</a>',
+			'paypal'  => '<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Donate', 'snitch' ) . '</a>',
+			'wiki'    => '<a href="https://github.com/pluginkollektiv/snitch/wiki" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Manual', 'snitch' ) . '</a>',
 			'support' => '<a href="https://wordpress.org/support/plugin/snitch" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Support', 'snitch' ) . '</a>',
 		);
 

--- a/inc/class-snitch-http.php
+++ b/inc/class-snitch-http.php
@@ -276,7 +276,7 @@ class Snitch_HTTP {
 
 		/* Frontend */
 		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
 		/* All active plugins */

--- a/inc/class-snitch-http.php
+++ b/inc/class-snitch-http.php
@@ -36,7 +36,7 @@ class Snitch_HTTP {
 		}
 
 		/* Invalid host */
-		$host = parse_url( $url, PHP_URL_HOST );
+		$host = wp_parse_url( $url, PHP_URL_HOST );
 		if ( ! $host ) {
 			return $pre;
 		}
@@ -129,7 +129,7 @@ class Snitch_HTTP {
 		}
 
 		/* Validate host */
-		$host = parse_url( $url, PHP_URL_HOST );
+		$host = wp_parse_url( $url, PHP_URL_HOST );
 		if ( ! $host ) {
 			return false;
 		}
@@ -363,7 +363,7 @@ class Snitch_HTTP {
 	 */
 	private static function _is_internal( $host ) {
 		/* Get the blog host */
-		$blog_host = parse_url(
+		$blog_host = wp_parse_url(
 			get_bloginfo( 'url' ),
 			PHP_URL_HOST
 		);

--- a/inc/class-snitch-http.php
+++ b/inc/class-snitch-http.php
@@ -193,7 +193,7 @@ class Snitch_HTTP {
 			if ( ! empty( $item['function'] ) && strpos( $item['function'], 'wp_remote_' ) !== false ) {
 				/* Use prev item */
 				if ( empty( $item['file'] ) ) {
-					$item = $trace[ -- $index ];
+					$item = $trace[ --$index ];
 				}
 
 				/* Get file and line */
@@ -214,7 +214,7 @@ class Snitch_HTTP {
 	 * @return  array   $meta  Array mit Informationen.
 	 */
 	private static function _face_detect( $path ) {
-		 /* Default */
+		/* Default */
 		$meta = array(
 			'type' => 'WordPress',
 			'name' => 'Core',
@@ -256,7 +256,7 @@ class Snitch_HTTP {
 	 * @return  array|bool    Array mit Plugin-Daten.
 	 */
 	private static function _localize_plugin( $path ) {
-		 /* Check path */
+		/* Check path */
 		if ( strpos( $path, WP_PLUGIN_DIR ) === false ) {
 			return false;
 		}

--- a/inc/class-snitch.php
+++ b/inc/class-snitch.php
@@ -21,7 +21,7 @@ class Snitch {
 	 * @change  0.0.1
 	 */
 	public static function instance() {
-		 new self();
+		new self();
 	}
 
 	/**
@@ -31,7 +31,7 @@ class Snitch {
 	 * @change  1.0.5
 	 */
 	public function __construct() {
-		 /* Register CPT */
+		/* Register CPT */
 		add_action(
 			'init',
 			array(
@@ -79,9 +79,9 @@ class Snitch {
 
 		/* Skip secondary hooks */
 		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
-			 || ( defined( 'DOING_CRON' ) && DOING_CRON )
-			 || ( defined( 'DOING_AJAX' ) && DOING_AJAX )
-			 || ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
+			|| ( defined( 'DOING_CRON' ) && DOING_CRON )
+			|| ( defined( 'DOING_AJAX' ) && DOING_AJAX )
+			|| ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
 			return;
 		}
 
@@ -143,7 +143,7 @@ class Snitch {
 	 * @return  array          Array mit erweiterten Links
 	 */
 	public static function meta_links( $data, $file ) {
-		 /* Skip the rest */
+		/* Skip the rest */
 		if ( SNITCH_BASE !== $file ) {
 			return $data;
 		}
@@ -199,7 +199,7 @@ class Snitch {
 	public static function updated_notice() {
 		/* Skip requests */
 		if ( 'plugins.php' !== $GLOBALS['pagenow']
-			 || ! ( defined( 'WP_HTTP_BLOCK_EXTERNAL' ) && WP_HTTP_BLOCK_EXTERNAL ) ) {
+			|| ! ( defined( 'WP_HTTP_BLOCK_EXTERNAL' ) && WP_HTTP_BLOCK_EXTERNAL ) ) {
 			return;
 		}
 
@@ -342,7 +342,7 @@ class Snitch {
 	 * @change  1.0.5
 	 */
 	public static function deactivation() {
-		 wp_clear_scheduled_hook( 'snitch_cleanup' );
+		wp_clear_scheduled_hook( 'snitch_cleanup' );
 	}
 
 	/**

--- a/inc/class-snitch.php
+++ b/inc/class-snitch.php
@@ -204,7 +204,7 @@ class Snitch {
 		}
 
 		/* Print */
-		echo sprintf(
+		printf(
 			'<div class="error"><p>%s</p></div>',
 			wp_kses(
 				__( 'Outgoing connections are blocked in <code>wp-config.php</code>. Check the constant <code>WP_HTTP_BLOCK_EXTERNAL</code>.', 'snitch' ),

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,7 +20,10 @@
 
     <!-- WordPress coding standards -->
     <config name="minimum_supported_wp_version" value="3.8" />
-    <rule ref="WordPress" />
+    <rule ref="WordPress">
+        <exclude name="Modernize.FunctionCalls.Dirname.FileConstant"/>
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
+    </rule>
     <rule ref="WordPress.WP.I18n">
         <properties>
             <property name="text_domain" type="array" value="snitch" />

--- a/snitch.php
+++ b/snitch.php
@@ -86,12 +86,10 @@ spl_autoload_register( 'snitch_autoload' );
  */
 function snitch_autoload( $class ) {
 	if ( in_array( $class, array( 'Snitch', 'Snitch_HTTP', 'Snitch_CPT', 'Snitch_Blocklist' ) ) ) {
-		require_once(
-			sprintf(
-				'%s/inc/class-%s.php',
-				SNITCH_DIR,
-				strtolower( str_replace( '_', '-', $class ) )
-			)
+		require_once sprintf(
+			'%s/inc/class-%s.php',
+			SNITCH_DIR,
+			strtolower( str_replace( '_', '-', $class ) )
 		);
 	}
 }

--- a/snitch.php
+++ b/snitch.php
@@ -82,14 +82,14 @@ spl_autoload_register( 'snitch_autoload' );
 /**
  * Autoload the class.
  *
- * @param string $class the class name.
+ * @param string $class_name the class name.
  */
-function snitch_autoload( $class ) {
-	if ( in_array( $class, array( 'Snitch', 'Snitch_HTTP', 'Snitch_CPT', 'Snitch_Blocklist' ) ) ) {
+function snitch_autoload( $class_name ) {
+	if ( in_array( $class_name, array( 'Snitch', 'Snitch_HTTP', 'Snitch_CPT', 'Snitch_Blocklist' ) ) ) {
 		require_once sprintf(
 			'%s/inc/class-%s.php',
 			SNITCH_DIR,
-			strtolower( str_replace( '_', '-', $class ) )
+			strtolower( str_replace( '_', '-', $class_name ) )
 		);
 	}
 }


### PR DESCRIPTION
* use `printf()` instead of `echo sprintf()`
* remove parentheses around `require_once`
* fix precision alignment, equals signs and double arrows
* rename `$class` parameter of autoload function to `$class_name`
* use `wp_parse_url()` instead of `parse_url()`
* update WPCS definitions to v3.0 (runs with PHP 8.2)