### PR TITLE
[i18n] Add plural translation to %s seconds

### DIFF
--- a/inc/class-snitch-cpt.php
+++ b/inc/class-snitch-cpt.php
@@ -640,10 +640,17 @@ class Snitch_CPT {
 	private static function _html_duration( $post_id ) {
 		$duration = self::_get_meta( $post_id, 'duration' );
 		if ( $duration ) {
-			echo sprintf(
-				/* translators: duration in seconds */
-				esc_html__( '%s seconds', 'snitch' ),
-				esc_html( $duration )
+			echo esc_html(
+				sprintf(
+					/* translators: duration in seconds */
+					_n(
+						'%s second',
+						'%s seconds',
+						$duration,
+						'snitch'
+					),
+					$duration
+				)
 			);
 		}
 	}


### PR DESCRIPTION
Add support for singular/plural to the duration column info `%s second` / `%s seconds`.