### PR TITLE
Don't remove slashes in file path

### DIFF
--- a/inc/class-snitch-cpt.php
+++ b/inc/class-snitch-cpt.php
@@ -542,7 +542,7 @@ class Snitch_CPT {
 
 		/* Print output */
 		echo sprintf(
-			'<div><p class="label blacklisted-%d"></p>%s: %s<br /><code>/%s:%d</code><div class="row-actions">%s</div></div>',
+			'<div><p class="label blacklisted-%d"></p>%s: %s<br /><code>%s:%d</code><div class="row-actions">%s</div></div>',
 			esc_attr( $blacklisted ),
 			esc_html( $meta['type'] ),
 			esc_html( $meta['name'] ),
@@ -794,7 +794,7 @@ class Snitch_CPT {
 			add_post_meta(
 				$post_id,
 				'_snitch_' . $key,
-				$value,
+				wp_slash( $value ),
 				true
 			);
 		}


### PR DESCRIPTION
This PR fixes the removal of slashes in the meta `_snitch_file` as seen below:

Wrong:
![imagem](https://github.com/pluginkollektiv/snitch/assets/7371591/04cf5a83-5f5d-4adb-a4fe-2591540b42c0)

Fixed:
![imagem](https://github.com/pluginkollektiv/snitch/assets/7371591/955aaaba-9c75-4abd-9af3-332e9ff0375b)

Also removes the leading slash /.

Fixes #54 