### PR TITLE
prepare release of v1.2.1

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,6 +2,7 @@
 /.git
 /.github
 /.wordpress-org
+/dist
 /node_modules
 /vendor
 

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,30 @@
+name: Plugin check
+on:
+  push:
+    branches: [ 'release/*' ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Build
+        run:  composer install --no-interaction
+
+      - name: Package plugin
+        run: |
+          mkdir -p ./dist
+          rsync -rc --exclude-from=.distignore ./ ./dist/snitch --delete --delete-excluded
+
+      - name: Check WP plugin
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: ./dist/snitch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Snitch changelog
 
+## 1.2.1
+* **English**
+  * Tested up to WordPress 6.8
+  * Minor code-style adjustments (#51)
+  * Add plural translation to "seconds" (#52)
+  * Slashes in file paths are no longer removed (output issues on Windows systems) (#53) (#54)
+  * Added link to Patchstack mVDP (#56)
+* **Deutsch**
+  * Getestet bis WordPress 6.8
+  * Kleinere Code-Style Anpassungen (#51)
+  * Plural Übersetzung für "Seconds" hinzugefügt (#52)
+  * Slashes in Dateipfaden werden nicht mehr entfernt (Anzeigefehler Windows-Systemen) (#53) (#54)
+  * Link zu Patchstack mVDP hinzugefügt (#56)
+
 ## 1.2.0
 * **English**
   * Shows schema of request (http/https)

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 # Snitch #
 * Contributors:      pluginkollektiv
 * Donate link:       https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=TD4AMD2D8EMZW
-* Tags:              sniffer, snitch, network, monitoring, firewall, GDPR
+* Tags:              sniffer, network, monitoring, firewall, GDPR
 * Requires at least: 3.8
-* Tested up to:      6.4
+* Tested up to:      6.8
 * Requires PHP:      5.2.4
-* Stable tag:        1.2.0
+* Stable tag:        1.2.1
 * License:           GPLv3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0
 
@@ -96,6 +96,13 @@ Please report security bugs found in the source code of the Snitch plugin throug
 
 
 ## Changelog ##
+
+### 1.2.1 ###
+* Tested up to WordPress 6.8
+* Minor code-style adjustments
+* Add plural translation to "seconds"
+* Slashes in file paths are no longer removed (output issues on Windows systems)
+* Added link to Patchstack mVDP
 
 ### 1.2.0 ###
 * Shows schema of request (http/https)

--- a/snitch.php
+++ b/snitch.php
@@ -7,7 +7,7 @@
  * Plugin URI:  https://snitch.pluginkollektiv.org/
  * License:     GPLv3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0
- * Version:     1.2.0
+ * Version:     1.2.1
  * Text Domain: snitch
  *
  * @package Snitch
@@ -15,7 +15,7 @@
 
 /*
 Copyright (C)  2013-2015 Sergej Müller
-Copyright (C)  2015-2019 Pluginkollektiv
+Copyright (C)  2015-2025 Pluginkollektiv
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
* bump stable plugin version to 1.2.1
* raise "tested up to" to WordPress 6.8
* add changelog entries
* remove excess tags from readme.txt
* add CI workflow to run wp plugin checks